### PR TITLE
Update package name and version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "listen-kit"
-version = "0.3.0"
+name = "rig-onchain-kit"
+version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Blockchain actions for AI agents"


### PR DESCRIPTION
This commit updates the package metadata in Cargo.toml by changing the package name from "listen-kit" to "rig-onchain-kit" and adjusting the version from "0.3.0" to "0.1.0". These changes ensure that the package accurately reflects the intended branding and  release version.