### PR TITLE
Jupiter portfolio may return incorrect data if token metadata not found

### DIFF
--- a/examples/solana_agent.rs
+++ b/examples/solana_agent.rs
@@ -11,18 +11,27 @@ use {
 #[cfg(feature = "solana")]
 #[tokio::main]
 async fn main() -> Result<()> {
+    use rig::{
+        message::{Text, UserContent},
+        OneOrMany,
+    };
+
     let signer = LocalSolanaSigner::new(env("SOLANA_PRIVATE_KEY"));
 
     SignerContext::with_signer(Arc::new(signer), async {
-        let trader_agent = Arc::new(create_solana_agent().await?);
-        let wrapped_agent = ReasoningLoop::new(trader_agent).with_stdout(true);
+        let trader_agent = Arc::new(create_solana_agent(None).await?);
+        let wrapped_agent =
+            ReasoningLoop::new(trader_agent).with_stdout(true);
 
         wrapped_agent
-            .stream(vec![Message {
-                role: "user".to_string(),
-                content: "what is the liquidity in the pool for my largest holding?"
-                    .to_string(),
-            }], None)
+            .stream(
+                vec![Message::User {
+                    content: OneOrMany::one(UserContent::Text(Text {
+                        text: "what is the liquidity in the pool for my largest holding?".to_string(),
+                    })),
+                }],
+                None,
+            )
             .await?;
 
         Ok(())

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -74,35 +74,37 @@ async fn stream(
     // Select the appropriate agent based on the chain parameter and preamble
     let agent = match request.chain.as_deref() {
         #[cfg(feature = "solana")]
-        Some("solana") => match create_solana_agent(preamble).await {
-            Ok(agent) => Arc::new(agent),
-            Err(e) => {
-                let error_event = sse::Event::Data(sse::Data::new(
-                    serde_json::to_string(&StreamResponse::Error(format!(
-                        "Failed to create Solana agent: {}",
-                        e
-                    )))
-                    .unwrap(),
-                ));
-                let _ = tx.send(error_event).await;
-                return sse::Sse::from_infallible_receiver(rx);
+        Some("solana") => {
+            match crate::solana::agent::create_solana_agent(preamble).await {
+                Ok(agent) => Arc::new(agent),
+                Err(e) => {
+                    let error_event = sse::Event::Data(sse::Data::new(
+                        serde_json::to_string(&StreamResponse::Error(
+                            format!("Failed to create Solana agent: {}", e),
+                        ))
+                        .unwrap(),
+                    ));
+                    let _ = tx.send(error_event).await;
+                    return sse::Sse::from_infallible_receiver(rx);
+                }
             }
-        },
+        }
         #[cfg(feature = "evm")]
-        Some("evm") => match create_evm_agent(preamble).await {
-            Ok(agent) => Arc::new(agent),
-            Err(e) => {
-                let error_event = sse::Event::Data(sse::Data::new(
-                    serde_json::to_string(&StreamResponse::Error(format!(
-                        "Failed to create EVM agent: {}",
-                        e
-                    )))
-                    .unwrap(),
-                ));
-                let _ = tx.send(error_event).await;
-                return sse::Sse::from_infallible_receiver(rx);
+        Some("evm") => {
+            match crate::evm::agent::create_evm_agent(preamble).await {
+                Ok(agent) => Arc::new(agent),
+                Err(e) => {
+                    let error_event = sse::Event::Data(sse::Data::new(
+                        serde_json::to_string(&StreamResponse::Error(
+                            format!("Failed to create EVM agent: {}", e),
+                        ))
+                        .unwrap(),
+                    ));
+                    let _ = tx.send(error_event).await;
+                    return sse::Sse::from_infallible_receiver(rx);
+                }
             }
-        },
+        }
         Some("omni") => match create_cross_chain_agent(preamble).await {
             Ok(agent) => Arc::new(agent),
             Err(e) => {

--- a/src/solana/data.rs
+++ b/src/solana/data.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use futures::future::join_all;
 use reqwest::Client;
@@ -67,7 +69,7 @@ pub async fn holdings_to_portfolio(
 ) -> Result<Vec<PortfolioItem>> {
     let client = Client::new();
 
-    // Fetch metadata for all tokens
+    // Fetch metadata concurrently for all tokens.
     let metadata_futures: Vec<_> = holdings
         .iter()
         .map(|holding| {
@@ -81,46 +83,59 @@ pub async fn holdings_to_portfolio(
         .collect();
 
     let metadata_results = join_all(metadata_futures).await;
-    let token_metadata: Vec<TokenMetadata> = metadata_results
+
+    // Build a map keyed by the token's address.
+    let token_metadata_map: HashMap<String, TokenMetadata> = metadata_results
         .into_iter()
         .filter_map(Result::ok)
-        .collect::<Vec<_>>();
+        .map(|metadata| (metadata.address.clone(), metadata))
+        .collect();
 
-    // Fetch prices for all tokens
+    // Fetch price data for all tokens.
     let mints: Vec<_> = holdings.iter().map(|h| h.mint.as_str()).collect();
     let prices_url =
         format!("https://api.jup.ag/price/v2?ids={}", mints.join(","));
     let price_response: PriceResponse =
         client.get(&prices_url).send().await?.json().await?;
 
-    // Combine all data into portfolio items
+    // Construct portfolio items by matching holdings with metadata.
     let portfolio: Vec<PortfolioItem> = holdings
         .iter()
-        .zip(token_metadata.iter())
-        .map(|(holding, metadata)| {
-            let price = price_response
-                .data
-                .get(&holding.mint)
-                .map(|p| match p {
-                    Some(price_data) => {
-                        price_data.price.parse::<f64>().unwrap_or(0.0)
-                    }
-                    None => 0.0,
+        .filter_map(|holding| {
+            // Look up metadata using the mint as key.
+            if let Some(metadata) =
+                token_metadata_map.get(&holding.mint.to_string())
+            {
+                let price = price_response
+                    .data
+                    .get(&holding.mint)
+                    .map(|p| match p {
+                        Some(price_data) => {
+                            price_data.price.parse::<f64>().unwrap_or(0.0)
+                        }
+                        None => 0.0,
+                    })
+                    .unwrap_or(0.0);
+
+                let amount = holding.amount as f64
+                    / (10f64.powi(metadata.decimals as i32));
+
+                Some(PortfolioItem {
+                    address: metadata.address.clone(),
+                    name: metadata.name.clone(),
+                    symbol: metadata.symbol.clone(),
+                    decimals: metadata.decimals,
+                    logo_uri: metadata.logo_uri.clone(),
+                    price,
+                    amount,
+                    daily_volume: metadata.volume_24h.unwrap_or(0.0),
                 })
-                .unwrap_or(0.0);
-
-            let amount = holding.amount as f64
-                / (10f64.powi(metadata.decimals as i32));
-
-            PortfolioItem {
-                address: metadata.address.clone(),
-                name: metadata.name.clone(),
-                symbol: metadata.symbol.clone(),
-                decimals: metadata.decimals,
-                logo_uri: metadata.logo_uri.clone(),
-                price,
-                amount,
-                daily_volume: metadata.volume_24h.unwrap_or(0.0),
+            } else {
+                eprintln!(
+                    "Missing metadata for holding with mint: {}",
+                    holding.mint
+                );
+                None
             }
         })
         .collect();

--- a/src/solana/data.rs
+++ b/src/solana/data.rs
@@ -145,6 +145,7 @@ pub async fn holdings_to_portfolio(
 
 #[cfg(test)]
 mod tests {
+    use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signer::Signer;
 
     use super::*;
@@ -161,5 +162,41 @@ mod tests {
         .unwrap();
 
         holdings_to_portfolio(holdings).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_holdings_to_portfolio_with_non_existing_token() {
+        let holdings = vec![
+            Holding {
+                mint: "DriFtupJYLTosbwoN8koMbEYSx54aFAVLddWsbksjwg7"
+                    .to_string(), // Drift
+                ata: "omit".to_string(),
+                amount: 10,
+            },
+            Holding {
+                mint: Pubkey::new_unique().to_string(), // non existing
+                ata: "omit".to_string(),
+                amount: 10,
+            },
+            Holding {
+                mint: "3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh"
+                    .to_string(), // WBTC
+                ata: "omit".to_string(),
+                amount: 10,
+            },
+        ];
+
+        let portfolio = holdings_to_portfolio(holdings).await.unwrap();
+        assert_eq!(portfolio.len(), 2);
+        assert_eq!(
+            portfolio[0].address,
+            "DriFtupJYLTosbwoN8koMbEYSx54aFAVLddWsbksjwg7".to_string()
+        );
+        assert_eq!(portfolio[0].name, "Drift".to_string());
+        assert_eq!(
+            portfolio[1].address,
+            "3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh".to_string()
+        );
+        assert_eq!(portfolio[1].name, "Wrapped BTC (Portal)".to_string());
     }
 }


### PR DESCRIPTION
Previously, if a wallet held any token that isn’t available via the Jupiter API, the portfolio calculation code would attempt to combine holdings and token metadata by zipping two collections. This approach assumed that the lengths of the holdings and token metadata vectors matched, which isn’t the case when some metadata requests fail (e.g., the token does not exist in the API).  As a result, the final portfolio could contain mismatched or incorrect data.

This PR:

- **Identifies the Issue:** Detects when a token’s metadata is missing from the Jupiter API.
- **Fixes the Problem:** Filters out any portfolio items for which token metadata is missing, ensuring that only holdings with valid metadata are included.
- **Prevents Mismatch:** By not pairing holdings with a missing metadata entry, this fix ensures that the final portfolio data is accurate and consistent.
